### PR TITLE
[feat] Navbar

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -1,0 +1,16 @@
+- name: Home
+  href: /
+
+- name: Blog
+  href: /blog
+  # make sure g isn't cut off
+  z-index: 1
+
+- name: Team
+  href: /team
+
+- name: CTFs
+  href: /ctfs
+
+- name: Archive
+  href: /archive

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,50 +1,51 @@
 <nav>
     <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
         <defs>
-            {% for i in (0..16) %}
+            {%- for i in (0..16) -%}
                 <g id="{% if i != 16 %}{{ i }}{% else %}x{% endif %}">
-                {% for j in (0..15) %}
+                {%- for j in (0..15) -%}
                     <text x="0" y="0" class="nav-num" style="transform: translateY(calc({{ j }} * var(--y-spacing)))">
-                        {% if i != 16 %}
-                            {{ i }}
-                        {% else %}
-                            {% if j < 10 %}
-                                {{ j }}
-                            {% else %}
-                                {% capture to_hex %}%4{{ j | minus: 9 }}{% endcapture %}
-                                {{ to_hex | url_decode }}
-                            {% endif %}
-                        {% endif %}
+                        {%- if i != 16 -%}
+                            {{- i -}}
+                        {%- else -%}
+                            {%- if j < 10 -%}
+                                {{- j -}}
+                            {%- else -%}
+                                {%- capture to_hex -%}%4{{- j | minus: 9 -}}{%- endcapture -%}
+                                {{- to_hex | url_decode -}}
+                            {%- endif -%}
+                        {%- endif -%}
                     </text>
-                {% endfor %}
+                {%- endfor -%}
                 </g>
-            {% endfor %}
+            {%- endfor -%}
             <g id="0s">
                 <use xlink:href="#0" style="transform: translateX(calc(7 * var(--x-spacing)))" />
-                {% for j in (0..4) %}
+                {%- for j in (0..4) -%}
                     <use xlink:href="#0" style="transform: translateX(calc({{ j }} * var(--x-spacing)))" />
-                {% endfor %}
+                {%- endfor -%}
             </g>
         </defs>
         <g style="transform: translateY(var(--font-size))">
-            {% for i in (0..4) %}
-                {% capture y-offset %}calc({{ i }} * var(--y-spacing) * 16{% endcapture %}
+            {%- for i in (0..4) -%}
+                {%- capture y-offset -%}calc({{ i }} * var(--y-spacing) * 16{%- endcapture -%}
                 <use xlink:href="#0s" style="transform: translateY({{ y-offset }})" />
                 <use xlink:href="#x" style="transform: translate(calc(6 * var(--x-spacing)), {{ y-offset }})" />
                 <use xlink:href="#{{ i }}" style="transform: translate(calc(5 * var(--x-spacing)), {{ y-offset }})" />
-            {% endfor %}
+            {%- endfor -%}
         </g>
     </svg>
     <ul>
-        {% assign stripped-page-url = page.url | remove: ".html" %}
-        {% for entry in site.data.navbar %}
-            <li {% if entry.z-index != nil %}style="z-index: {{ entry.z-index }};"{% endif %}>
+        {%- assign stripped-page-url = page.url | remove: ".html" -%}
+        {%- for entry in site.data.navbar -%}
+            <li {% if entry.z-index != nil -%}style="z-index: {{ entry.z-index }};"{%- endif -%}>
                 <a href="{{ entry.href }}"
                    title="{{ entry.name }}"
-                   {% if stripped-page-url == entry.href %}highlighted{% endif %}
-                >{{ entry.name | truncate: 4, "" }}</a>
-                {%- comment -%} DO NOT change the spacing of the above line - see https://stackoverflow.com/q/2628050 {%- endcomment -%}
+                   {%- if stripped-page-url == entry.href -%}highlighted{%- endif -%}
+                >
+                    {{- entry.name | truncate: 4, "" -}}
+                </a>
             </li>
-        {% endfor %}
+        {%- endfor -%}
     </ul>
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -35,13 +35,16 @@
             {% endfor %}
         </g>
     </svg>
-    <!--
     <ul>
-        <li><a href="/">Home</a></li>
-        <li><a href="/blog">Blog</a></li>
-        <li><a href="/team">Team</a></li>
-        <li><a href="/ctfs">CTFs</a></li>
-        <li><a href="/archive">Archive</a></li>
+        {% assign stripped-page-url = page.url | remove: ".html" %}
+        {% for entry in site.data.navbar %}
+            <li {% if entry.z-index != nil %}style="z-index: {{ entry.z-index }};"{% endif %}>
+                <a href="{{ entry.href }}"
+                   title="{{ entry.name }}"
+                   {% if stripped-page-url == entry.href %}highlighted{% endif %}
+                >{{ entry.name | truncate: 4, "" }}</a>
+                {%- comment -%} DO NOT change the spacing of the above line - see https://stackoverflow.com/q/2628050 {%- endcomment -%}
+            </li>
+        {% endfor %}
     </ul>
-    -->
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,41 @@
 <nav>
+    <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            {% for i in (0..16) %}
+                <g id="{% if i != 16 %}{{ i }}{% else %}x{% endif %}">
+                {% for j in (0..15) %}
+                    <text x="0" y="0" class="nav-num" style="transform: translateY(calc({{ j }} * var(--y-spacing)))">
+                        {% if i != 16 %}
+                            {{ i }}
+                        {% else %}
+                            {% if j < 10 %}
+                                {{ j }}
+                            {% else %}
+                                {% capture to_hex %}%4{{ j | minus: 9 }}{% endcapture %}
+                                {{ to_hex | url_decode }}
+                            {% endif %}
+                        {% endif %}
+                    </text>
+                {% endfor %}
+                </g>
+            {% endfor %}
+            <g id="0s">
+                <use xlink:href="#0" style="transform: translateX(calc(7 * var(--x-spacing)))" />
+                {% for j in (0..4) %}
+                    <use xlink:href="#0" style="transform: translateX(calc({{ j }} * var(--x-spacing)))" />
+                {% endfor %}
+            </g>
+        </defs>
+        <g style="transform: translateY(var(--font-size))">
+            {% for i in (0..4) %}
+                {% capture y-offset %}calc({{ i }} * var(--y-spacing) * 16{% endcapture %}
+                <use xlink:href="#0s" style="transform: translateY({{ y-offset }})" />
+                <use xlink:href="#x" style="transform: translate(calc(6 * var(--x-spacing)), {{ y-offset }})" />
+                <use xlink:href="#{{ i }}" style="transform: translate(calc(5 * var(--x-spacing)), {{ y-offset }})" />
+            {% endfor %}
+        </g>
+    </svg>
+    <!--
     <ul>
         <li><a href="/">Home</a></li>
         <li><a href="/blog">Blog</a></li>
@@ -6,4 +43,5 @@
         <li><a href="/ctfs">CTFs</a></li>
         <li><a href="/archive">Archive</a></li>
     </ul>
+    -->
 </nav>

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -11,7 +11,8 @@ body {
   color: #ffffff;
   font-family: "IBM Plex Mono", "Consolas", "Lucida Console", monospace;
 
-  --nav-width: calc(10% + 2rem);
+  --min-nav-inner-width: 80px;
+  --nav-width: calc(max(var(--min-nav-inner-width), 10%) + 2rem);
 }
 
 a {

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -10,6 +10,8 @@ body {
   background-color: #2c2c2c;
   color: #ffffff;
   font-family: "IBM Plex Mono", "Consolas", "Lucida Console", monospace;
+
+  --nav-width: calc(10% + 2rem);
 }
 
 a {

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500&display=swap');
 
 html,
 body {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,5 +1,5 @@
 .content {
-    margin-left: 10rem;
+    margin-left: 10%;
 
     main {
         padding: 5rem 10%;

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,5 +1,5 @@
 .content {
-    margin-left: 10%;
+    margin-left: var(--nav-width);
 
     main {
         padding: 5rem 10%;

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -8,7 +8,7 @@ nav {
     left: 0;
     bottom: 0;
     padding: 1rem 0rem 0rem 1rem;
-    width: 10%;
+    width: calc(var(--nav-width) - 2rem);
 
     ul {
         display: flex;

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -11,25 +11,46 @@ nav {
     padding: 1rem 0rem 0rem 1rem;
     width: calc(var(--nav-width) - 2rem);
 
+    svg {
+        position: absolute;
+        user-select: none;
+        pointer-events: none;
+    }
+
     ul {
+        position: absolute;
         display: flex;
         flex-direction: column;
         list-style-type: none;
         margin: 0;
-        padding: 1rem;
+        padding: 0;
+        width: calc(var(--x-spacing) * 8);
         align-items: center;
+        font-size: var(--font-size);
 
         li {
-            margin: 0.5em 0;
+            height: 0px;
+            margin: var(--y-spacing) 0 0 0;
 
             a {
+                display: inline-block;
+                width: 100%;
                 color: #FFFFFF;
+                background-color: #2C2C2C;
                 text-decoration: none;
                 text-align: center;
-            }
 
-            a:hover {
-                color: #FFBD3F;
+                &[highlighted], &:hover {
+                    color: #FFBD3F;
+                }
+
+                &[highlighted]::before {
+                    content: ">>";
+                }
+
+                &[highlighted]::after {
+                    content: "<<";
+                }
             }
         }
     }

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -1,11 +1,14 @@
 nav {
-    background-color: #6B6B6B;
+    --font-size: 2.1vw;
+    --x-spacing: calc(var(--font-size) * 0.585);
+    --y-spacing: calc(var(--font-size) * 1.18);
+
     position: fixed;
     top: 0;
     left: 0;
     bottom: 0;
-    font-size: 2vw;
-    width: 10rem;
+    padding: 1rem 0rem 0rem 1rem;
+    width: 10%;
 
     ul {
         display: flex;
@@ -29,4 +32,12 @@ nav {
             }
         }
     }
+}
+
+/** styling inline svgs only seems to work with top-level classes */
+.nav-num {
+    fill: #6B6B6B;
+    font-size: 2.1vw;
+    user-select: none;
+    pointer-events: none;
 }

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -1,9 +1,10 @@
 nav {
-    --font-size: 2.1vw;
+    --font-size: max(2.1vw, calc(0.21 * var(--min-nav-inner-width)));
     --x-spacing: calc(var(--font-size) * 0.585);
     --y-spacing: calc(var(--font-size) * 1.18);
 
     position: fixed;
+    overflow-y: hidden;
     top: 0;
     left: 0;
     bottom: 0;
@@ -37,7 +38,7 @@ nav {
 /** styling inline svgs only seems to work with top-level classes */
 .nav-num {
     fill: #6B6B6B;
-    font-size: 2.1vw;
+    font-size: var(--font-size);
     user-select: none;
     pointer-events: none;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45273859/224530215-b825e85a-b448-4a18-9387-f2b88a57eeb1.png)

## features
- implements navbar
- amazing (ab)use of the liquid template engine
- no javascript (derogatory) required

## things we need to QA / bikeshed
- on mobile: is the navbar too big?
  - it currently has an enforced min-width of 80px
- on mobile: does the navbar unintentionally scroll with the rest of the page?
  - Firefox's mobile emulator seems to do this, but I'm not sure if that's a bug in Firefox or an actual issue
- when resizing the window on Safari, does the navbar properly re-render?
  - WebKit on Linux seems to die on this, but I'd like a test from an actual Safari browser
- as given in the Figma, all of the subsection titles must be exactly 4 characters long for the styling to work, but this doesn't work for the `Archive` subsection.
  - I've replaced `Archive` with `Arch` for now, but some suggestions for what we should call the archive category from the Discord have included `tomb`, `past`, `hist`, and `stuf`
 