### PR TITLE
[fix] navbar, for once and for all

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,41 +1,13 @@
 <nav>
-    <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-            {%- for i in (0..16) -%}
-                <g id="{% if i != 16 %}{{ i }}{% else %}x{% endif %}">
-                {%- for j in (0..15) -%}
-                    <text x="0" y="0" class="nav-num" style="transform: translateY(calc({{ j }} * var(--y-spacing)))">
-                        {%- if i != 16 -%}
-                            {{- i -}}
-                        {%- else -%}
-                            {%- if j < 10 -%}
-                                {{- j -}}
-                            {%- else -%}
-                                {%- capture to_hex -%}%4{{- j | minus: 9 -}}{%- endcapture -%}
-                                {{- to_hex | url_decode -}}
-                            {%- endif -%}
-                        {%- endif -%}
-                    </text>
-                {%- endfor -%}
-                </g>
+    <div class="hex" role="img" aria-label="Navigation bar background graphic, styled like the address panel of a hex editor.">
+        <ol>
+            {%- for i in (0..256) -%}
+                <li/>
             {%- endfor -%}
-            <g id="0s">
-                <use xlink:href="#0" style="transform: translateX(calc(7 * var(--x-spacing)))" />
-                {%- for j in (0..4) -%}
-                    <use xlink:href="#0" style="transform: translateX(calc({{ j }} * var(--x-spacing)))" />
-                {%- endfor -%}
-            </g>
-        </defs>
-        <g style="transform: translateY(var(--font-size))">
-            {%- for i in (0..4) -%}
-                {%- capture y-offset -%}calc({{ i }} * var(--y-spacing) * 16{%- endcapture -%}
-                <use xlink:href="#0s" style="transform: translateY({{ y-offset }})" />
-                <use xlink:href="#x" style="transform: translate(calc(6 * var(--x-spacing)), {{ y-offset }})" />
-                <use xlink:href="#{{ i }}" style="transform: translate(calc(5 * var(--x-spacing)), {{ y-offset }})" />
-            {%- endfor -%}
-        </g>
-    </svg>
+        </ol>
+    </div>
     <ul>
+        <li aria-hidden="true">0</li>
         {%- assign stripped-page-url = page.url | remove: ".html" -%}
         {%- for entry in site.data.navbar -%}
             <li {% if entry.z-index != nil -%}style="z-index: {{ entry.z-index }};"{%- endif -%}>

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -61,7 +61,6 @@ nav {
         margin: 0;
         padding: 0;
         width: var(--nav-inner-width);
-        align-items: right;
         font-size: var(--font-size);
 
         li {

--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -1,20 +1,56 @@
 nav {
     --font-size: max(2.1vw, calc(0.21 * var(--min-nav-inner-width)));
-    --x-spacing: calc(var(--font-size) * 0.6);
-    --y-spacing: calc(var(--font-size) * 1.32);
+    --nav-inner-width: 5em;
 
     position: fixed;
-    overflow: clip clip;
+    overflow: visible;
     top: 0;
     left: 0;
     bottom: 0;
-    padding: 1rem 0rem 0rem 1rem;
+    padding: 1rem 0rem 0rem 0.7rem;
+    -webkit-padding-start: 0.4rem;
     width: calc(var(--nav-width) - 2rem);
 
-    svg {
+    div.hex {
         position: absolute;
+        width: var(--nav-inner-width);
+        padding-right: 1rem;
         user-select: none;
         pointer-events: none;
+
+        font-size: var(--font-size);
+        color: #6B6B6B;
+
+        ol {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+            counter-reset: hex -16;
+            isolation: isolate;
+
+            li {
+                position: relative;
+                display: flow-root;
+                counter-increment: hex 16;
+
+                &::before {
+                    content: "00000000";
+                    position: absolute;
+                    display: block;
+                    text-align: right;
+                    width: 100%;
+                }
+                
+                &::after {
+                    content: counter(hex, upper-hexadecimal);
+                    z-index: 1;
+                    position: relative;
+                    display: block;
+                    float: right;
+                    background-color: #2C2C2C;
+                }
+            }
+        }
     }
 
     ul {
@@ -24,21 +60,39 @@ nav {
         list-style-type: none;
         margin: 0;
         padding: 0;
-        width: calc(var(--x-spacing) * 8);
-        align-items: center;
+        width: var(--nav-inner-width);
+        align-items: right;
         font-size: var(--font-size);
 
         li {
-            height: 0px;
-            margin: var(--y-spacing) 0 0 0;
+            &:first-child {
+                opacity: 0%;
+                user-select: none;
+                pointer-events: none;
+            }
 
             a {
-                display: inline-block;
-                width: 100%;
+                display: block;
+                float: right;
+                isolation: isolate;
                 color: #FFFFFF;
-                background-color: #2C2C2C;
                 text-decoration: none;
                 text-align: center;
+
+                &:not([highlighted])::before {
+                    content: "\00a0\00a0\00a0\00a0";
+                    position: absolute;
+                    background-color: #2C2C2C;
+                    z-index: -1;
+                }
+
+                &:not([highlighted])::after {
+                    content: "\00a0\00a0";
+                }
+
+                &[highlighted] {
+                    background-color: #2C2C2C;
+                }
 
                 &[highlighted], &:hover {
                     color: #FFBD3F;
@@ -56,10 +110,12 @@ nav {
     }
 }
 
-/** styling inline svgs only seems to work with top-level classes */
-.nav-num {
-    fill: #6B6B6B;
-    font-size: var(--font-size);
-    user-select: none;
-    pointer-events: none;
+/*
+ * Safari doesn't support @counter-style but has
+ * upper-hexadecimal built-in, so using this name
+ * works for all browsers!
+ */
+@counter-style upper-hexadecimal {
+    system: numeric;
+    symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "A" "B" "C" "D" "E" "F";
 }


### PR DESCRIPTION
# features

- reject svg embrace css counters
- no more pixel-imperfect bugs
- conforms to virgin native text scaling
- works on safari (i think)

firefox
![image](https://user-images.githubusercontent.com/45273859/227745651-2d9fc6b6-cf77-45d7-82e0-9b7dcf2a03d8.png)

chrome
![image](https://user-images.githubusercontent.com/45273859/227745653-f4b6e712-0683-4183-8d88-a331d68a59e5.png)

"safari" (gnu/web)
![image](https://user-images.githubusercontent.com/45273859/227745663-1ec043de-8cb8-4f27-af22-c6e82cb49e53.png)
