### PR TITLE
fix: incorrect `Disallow` policy for `robots.txt`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow: /assets/
 
 Sitemap: https://pbr.uclaacm.com/sitemap.xml


### PR DESCRIPTION
@bkrl Raised an excellent observation that this prevents Googlebot from properly rendering the site when visiting. Removing the unnecessary `Disallow` policy. https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt