### PR TITLE
Fix splash screen font size

### DIFF
--- a/assets/styles/splash.scss
+++ b/assets/styles/splash.scss
@@ -18,8 +18,8 @@
     .term {
         font-family: "IBM Plex Mono", "Consolas", "Lucida Console", monospace;
         color: rgb(205, 205, 205);
-        font-size: 2rem;
-        line-height: calc(var(--nav-footer-line-height-multiplier) * 2rem);
+        font-size: 2vw;
+        line-height: calc(var(--nav-footer-line-height-multiplier) * 2vw);
         opacity: 0.8;
         overflow: hidden hidden;
     }


### PR DESCRIPTION
Looks like this one has to be relative to the window width to prevent the text from going past the edge of the screen on mobile.